### PR TITLE
dashboard-darknet.json: Update to latest MQTT client

### DIFF
--- a/config/dashboard-darknet.json
+++ b/config/dashboard-darknet.json
@@ -21,7 +21,7 @@
 				{
 					"type": "html",
 					"settings": {
-						"html": "imgstr = datasources[\"Detection Result\"][\"berrynet/engine/darknet/result\"][\"bytes\"]\ns = \"<img src=\\\"data:image/jpeg;base64,\" + imgstr + \"\\\" width=100% height=100%>\"\nreturn s\n\n",
+						"html": "imgstr = datasources[\"Detection Result\"][\"msg\"][\"bytes\"]\ns = \"<img src=\\\"data:image/jpeg;base64,\" + imgstr + \"\\\" width=100% height=100%>\"\nreturn s\n\n",
 						"height": 4
 					}
 				}
@@ -43,7 +43,7 @@
 				{
 					"type": "html",
 					"settings": {
-						"html": "s = datasources[\"Detection Result\"][\"berrynet/engine/darknet/result\"][\"annotations\"].map(function(r) {                      \n    return (r[\"label\"] + \": \" + r[\"confidence\"] + \"<br />\")\n}).join().replace(/,/g, \"\")\nconsole.log(s)\nreturn s",
+						"html": "s = datasources[\"Detection Result\"][\"msg\"][\"annotations\"].map(function(r) {                      \n    return (r[\"label\"] + \": \" + r[\"confidence\"] + \"<br />\")\n}).join().replace(/,/g, \"\")\nconsole.log(s)\nreturn s",
 						"height": 4
 					}
 				}
@@ -57,8 +57,12 @@
 			"settings": {
 				"server": "localhost",
 				"port": 3000,
+				"use_ssl": false,
 				"client_id": "freeboard_darknetres",
 				"topics": "berrynet/engine/darknet/result",
+				"json_data": true,
+				"username": "",
+				"password": "",
 				"name": "Detection Result"
 			}
 		}


### PR DESCRIPTION
The latest MQTT plugin for freeboard changes its configurations.
We need to add more field to the configuration, also
need to use "msg" instead of topic to query the results.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>